### PR TITLE
Properly stop conflicting gradle instances

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")" || return
 
 echo "In case of build errors, please verify that recent versions of docker and docker-compose are installed."
 echo ""
+# Stop potentially conflicting gradle daemons
+echo "Trying to stop potentially conflicting gradle daemons..."
+./gradlew --stop
+echo ""
 # Pull is allowed to fail, ignore if it happens.
 ! docker-compose -f docker-build/docker-compose.yml pull
 if [ -z "$*" ]; then

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -31,9 +31,6 @@ if [ "$TARGET_UID" == "root" ] || [ "$TARGET_UID" == "0" ]; then
   ln -s "$M2_DIR" /root/.m2
   echo "Build parameters passed: $*"
   echo "User running ./gradlew: $(id)"
-  # Stop potentially conflicting gradle daemons
-  echo "Stopping potentially conflicting gradle daemons..."
-  ./gradlew --stop
   # Run build using all arguments from CMD
   ./gradlew "$@"
 else
@@ -50,6 +47,5 @@ else
   # Run build using all arguments from CMD, passing correct HOME variable
   sudo -u build -E sh -c "export HOME=\"/home/build\";
     echo \"User running ./gradlew: \$(id)\";
-    echo \"Stopping potentially conflicting gradle daemons...\";
-    ./gradlew --stop; ./gradlew $*"
+    ./gradlew $*"
 fi


### PR DESCRIPTION
The code for stopping running gradle daemons was issued in the build container, and therefore apparently didn't have any effect.
Code was therefore moved to `build.sh`, where gradle daemons are stopped locally before running `docker-compose`.