### PR TITLE
docs: fix example README.md

### DIFF
--- a/examples/example-idscp2-uc/README.md
+++ b/examples/example-idscp2-uc/README.md
@@ -4,7 +4,7 @@ This example demonstrates client-server communication between trusted connectors
 including LUCON UC (Usage Control), limiting execution to a particular docker container, identified by its content hash.
 
 The example is started in the same way as described in `example-idscp2/README.md`, with the only difference that
-container names in `exec` commands (`server-core` and `client-core`) switch places.
+container names in `exec` commands (`consumer-core` and `provider-core`) switch places.
 
 If the UC demo fails, check whether the repo digest needs to be adapted in the XML file`example-idscp2-server.xml`
 (last part of DockerHub URI). 

--- a/examples/example-idscp2/README.md
+++ b/examples/example-idscp2/README.md
@@ -6,10 +6,10 @@ This examples demonstrate data transfer between trusted connectors via the IDSCP
 
 First, start the server (consumer) with the command `docker-compose -f docker-compose-server.yaml up`.
 When the Karaf shell appears, you may attach to it via a separate SSH client connection using the command
-`docker-compose -f docker-compose-server.yaml exec server-core bin/client`, and show logs output `log:tail`.
+`docker-compose -f docker-compose-server.yaml exec consumer-core bin/client`, and show logs output `log:tail`.
 
-Second, start the client (provider) using the command `docker-compose -f docker-compose-provider.yaml up`.
-When the Karaf shell appears, you may use `docker-compose -f docker-compose-provider.yaml exec client-core bin/client`
+Second, start the client (provider) using the command `docker-compose -f docker-compose-client.yaml up`.
+When the Karaf shell appears, you may use `docker-compose -f docker-compose-provider.yaml exec provider-core bin/client`
 and `log:tail` analogous to the server.
 
 ### Broadcast example


### PR DESCRIPTION
The service and files names in the README.md did not match the docker-compose-*.yaml files.

While we are at it: Attaching to the karaf shell with the exec command mentioned in the readme, does fail too:
`docker-compose -f docker-compose-server.yaml exec consumer-core bin/client
OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: exec: "bin/client": stat bin/client: no such file or directory: unknown`

Any suggestions?